### PR TITLE
Correction of problem with hover over Browse button

### DIFF
--- a/js/jQuery.fileinput.js
+++ b/js/jQuery.fileinput.js
@@ -73,7 +73,7 @@ $.fn.customFileInput = function(){
 		.mousemove(function(e){
 			fileInput.css({
 				'left': e.pageX - upload.offset().left - fileInput.outerWidth() + 20, //position right side 20px right of cursor X)
-				'top': e.pageY - upload.offset().top - 5
+				'top': e.pageY - upload.offset().top - 20
 			});	
 		})
 		.insertAfter(fileInput); //insert after the input

--- a/js/jQuery.fileinput.js
+++ b/js/jQuery.fileinput.js
@@ -73,7 +73,7 @@ $.fn.customFileInput = function(){
 		.mousemove(function(e){
 			fileInput.css({
 				'left': e.pageX - upload.offset().left - fileInput.outerWidth() + 20, //position right side 20px right of cursor X)
-				'top': e.pageY - upload.offset().top - $(window).scrollTop() - 3
+				'top': e.pageY - upload.offset().top - 5
 			});	
 		})
 		.insertAfter(fileInput); //insert after the input


### PR DESCRIPTION
Hello. 

I use jQuery 1.6.2.
I found problem with Browse button. 

When you have Browse button below currently visible part of page and you have to scroll down, then Browse button will stop reacting on hover events. The problem is in computation of 'top' coordinate.

rochejul's solution - from issue #2 was to replace (https://github.com/filamentgroup/jQuery-Custom-File-Input/issues/2#issuecomment-4301656):
'top': e.pageY - upload.offset().top - $(window).scrollTop() - 3
by:
'top': e.pageY - upload.offset().top - 20

This is correct and it works for me. Tested with Google Chrome 17, Firefox 9, Internet Explorer 9, Safari 5.1
